### PR TITLE
ci: use built-in GITHUB_TOKEN for release-drafter

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -67,6 +67,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, audit_ci, build, tests]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+      pull-requests: read
     steps:
       - uses: actions/checkout@v6
       - name: Release Drafter
@@ -74,4 +77,4 @@ jobs:
         with:
           config-name: release-drafter-config.yml
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PA_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Switch release-drafter from \`secrets.GH_PA_TOKEN\` (returning Bad credentials) to the built-in \`secrets.GITHUB_TOKEN\`
- Add explicit \`permissions: contents: write, pull-requests: read\` to the release_draft job

## Why
The post-merge run of #48 failed at the release-drafter step with \`HttpError: Bad credentials\` — \`GH_PA_TOKEN\` is expired/revoked. The built-in token is sufficient for drafting releases on the same repo, never expires, and removes the need to rotate a PAT.

## Test plan
- [ ] CI passes on this PR (release_drafter still skipped because the job is gated on push to main)
- [ ] After merge, post-merge run on main creates/updates the draft release without errors